### PR TITLE
Fix Classic Expedition land pinlines

### DIFF
--- a/templates.py
+++ b/templates.py
@@ -350,12 +350,20 @@ class ExpeditionClassicTemplate (NormalTemplate):
     """
 
     @property
+    def is_land(self) -> bool:
+        return False
+
+    @property
     def is_nyx(self) -> bool:
         return False
 
     @property
     def is_legendary(self) -> bool:
         return False
+
+    @property
+    def is_fullart(self) -> bool:
+        return True
 
     """
     LAYERS


### PR DESCRIPTION
- Pinlines now work for lands
- Also marked as "fullart" and added a second art reference to PSD